### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/src/Web/HealthChecks/SystemHealthCheck.cs
+++ b/src/Web/HealthChecks/SystemHealthCheck.cs
@@ -18,6 +18,11 @@ public class SystemHealthCheck : IHealthCheck
     {
         var request = _httpContextAccessor.HttpContext?.Request;
         string drive = request.Query.ContainsKey("drive") ? request.Query["drive"] : "C";
+        var allowedDrives = new HashSet<string> { "C", "D", "E", "F" }; // Define allowed drive letters
+        if (!allowedDrives.Contains(drive.ToUpper()))
+        {
+            return HealthCheckResult.Unhealthy("Invalid drive specified.");
+        }
         Process process = new Process();
         process.StartInfo.FileName = @"cmd.exe";
         process.StartInfo.Arguments = $"/C fsutil volume diskfree {drive}:";


### PR DESCRIPTION
Fixes [https://github.com/geovanams/eshop2/security/code-scanning/1](https://github.com/geovanams/eshop2/security/code-scanning/1)

To fix the problem, we need to validate the user input to ensure it is safe before using it in the command line. Specifically, we should restrict the `drive` parameter to a set of known safe values (e.g., "C", "D", etc.). This can be achieved by checking if the `drive` parameter is one of the allowed values before constructing the command line argument.

1. Define a set of allowed drive letters.
2. Check if the user-provided `drive` parameter is in the set of allowed values.
3. If the `drive` parameter is not valid, handle the error appropriately (e.g., return an unhealthy result or a default value).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
